### PR TITLE
Keybindings and movement improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# CONTRIBUTING
+
+Quick notes on how this projects was made and how to contribute, to be
+improved in the future.
+
+This project uses the [Amethyst](https://amethyst.rs/) game engine.
+
+
+## Map creation
+
+Artwork comes from [OpenGameArt.org](https://opengameart.org/content/zelda-like-tilesets-and-sprites).
+
+Maps are assembled from sprites using the ["Tiled" map editor](https://www.mapeditor.org/). Which
+yields `.tmx` files we can then parse in rust using the [rs-tiled
+crate](https://github.com/mattyhall/rs-tiled).
+
+## Keybindings
+
+The keybindings are described in the `resources/bindings.ron` file.
+You also need to create the propper enum variants in `src/key_bindings.rs` for our game to be able
+to parse the file properly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 amethyst = "0.13.2"
 log = { version = "0.4.8", features = ["serde"] }
 tiled = { git = "https://github.com/mattyhall/rs-tiled" }
+serde = { version = "1", features = ["derive"] }
 
 [features]
 default = ["vulkan"]

--- a/resources/bindings.ron
+++ b/resources/bindings.ron
@@ -1,9 +1,9 @@
 (
-  axes: {},
-  actions: {
-    "up":    [[  Key(W) ]],  
-    "down":  [[  Key(S) ]], 
-    "left":  [[  Key(A) ]], 
-    "right": [[  Key(D) ]] 
-  },
+    axes: {
+        Vertical: Emulated(pos: Key(W), neg: Key(S)),
+        Horizontal: Emulated(pos: Key(D), neg: Key(A)),
+    },
+    actions: {
+        Shoot: [[Key(Space)]],
+    },
 )

--- a/src/key_bindings.rs
+++ b/src/key_bindings.rs
@@ -1,0 +1,36 @@
+use std::fmt::{self, Display};
+
+use amethyst::input::BindingTypes;
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AxisBinding {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActionBinding {
+    Shoot,
+}
+
+impl Display for AxisBinding {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl Display for ActionBinding {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+pub struct MovementBindingTypes;
+
+impl BindingTypes for MovementBindingTypes {
+    type Axis = AxisBinding;
+    type Action = ActionBinding;
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,13 @@ use amethyst::{
         types::DefaultBackend,
         RenderingBundle,
     },
-    input::{InputBundle, StringBindings},
+    input::InputBundle,
     utils::application_root_dir,
 };
 
 pub mod state;
 pub mod map;
+pub mod key_bindings;
 mod systems;
 
 fn main() -> amethyst::Result<()> {
@@ -22,7 +23,7 @@ fn main() -> amethyst::Result<()> {
     let display_config = resources.join("display_config.ron");
     let binding_path = resources.join("bindings.ron");
     
-    let input_bundle = InputBundle::<StringBindings>::new()
+    let input_bundle = InputBundle::<key_bindings::MovementBindingTypes>::new()
         .with_bindings_from_file(binding_path)?;
 
     let rm = map::Room::new("resources/sprites/first.tmx".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> amethyst::Result<()> {
     let input_bundle = InputBundle::<key_bindings::MovementBindingTypes>::new()
         .with_bindings_from_file(binding_path)?;
 
-    let rm = map::Room::new("resources/sprites/first.tmx".to_string());
+    let room = map::Room::new("resources/sprites/first.tmx".to_string());
 
     let game_data = GameDataBuilder::default()
         .with_bundle(TransformBundle::new())?
@@ -41,10 +41,15 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(input_bundle)? 
         .with(systems::PlayerSystem, "player_system", &["input_system"]);
 
-    let mut game = Application::new(resources, 
-                                    state::GamePlayState{current_map: rm}, 
-                                    game_data)?;
+
+    let mut game = Application::new(
+        resources, 
+        state::GamePlayState{current_map: room}, 
+        game_data,
+    )?;
+
     game.run();
 
     Ok(())
 }
+

--- a/src/map.rs
+++ b/src/map.rs
@@ -5,12 +5,12 @@ use amethyst::{
     renderer::{ImageFormat, SpriteRender, SpriteSheet, SpriteSheetFormat, Texture},
     window::ScreenDimensions,
 };
+
 extern crate tiled;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 use log::info;
-use tiled::parse;
 
 pub struct Room {
     pub current: tiled::Map,   // Current room 
@@ -20,33 +20,34 @@ pub struct Room {
 
 // Comment
 impl Room {
-    pub fn new(fname: String) -> Self{
-        let file = File::open(&Path::new(&fname)).unwrap();
+    pub fn new(file_name: String) -> Self {
+        let file = File::open(&Path::new(&file_name)).unwrap();
     	let reader = BufReader::new(file);
-        let mp =  parse(reader).unwrap();
+        let map =  tiled::parse(reader).unwrap();
 
-        // info!("{:?}", mp);
+        // info!("{:?}", map);
 
-        Self{
-            tiles: Room::count_tiles(&mp), 
-            current: mp,
+        Self {
+            tiles: Room::count_tiles(&map), 
+            current: map,
             sprites: Vec::new(), 
         }
     }
    
-    fn count_tiles(mp: &tiled::Map) -> Vec<i32>{
+    fn count_tiles(map: &tiled::Map) -> Vec<i32> {
         let mut v: Vec<i32> = Vec::new();
-        for sets in &mp.tilesets{
+        for sets in &map.tilesets {
             v.push((sets.images[0].width / sets.tile_width as i32) * (sets.images[0].height / sets.tile_height as i32)) 
         }
+
         info!("Tiles in the images: {:?}", v);
 
         v
     }
-    
+
     pub fn load_sprites(&mut self, world: &mut World) {
         let mut ii = 0;
-    
+
         for sets in &self.current.tilesets {
             // Load the texture for our sprites. We'll later need to
             // add a handle to this texture to our `SpriteRender`s, so
@@ -54,6 +55,7 @@ impl Room {
             let texture_handle = {
                 let loader = world.read_resource::<Loader>();
                 let texture_storage = world.read_resource::<AssetStorage<Texture>>();
+
                 loader.load(
                     // "sprites/basictiles.png",
                     format!("sprites/{}.png", sets.name), 
@@ -68,6 +70,7 @@ impl Room {
             let sheet_handle = {
                 let loader = world.read_resource::<Loader>();
                 let sheet_storage = world.read_resource::<AssetStorage<SpriteSheet>>();
+
                 loader.load(
                     // "sprites/basictiles.ron",
                     format!("sprites/{}.ron", sets.name), 
@@ -76,26 +79,30 @@ impl Room {
                     &sheet_storage,
                 )
             };
-            
-           for i in 0..self.tiles[ii] { 
-               self.sprites.push(SpriteRender{
-                   sprite_sheet: sheet_handle.clone(),
-                   sprite_number: i as usize,
-               });
-           };
-           ii += 1;
+ 
+            for i in 0..self.tiles[ii] { 
+                self.sprites.push(SpriteRender {
+                    sprite_sheet: sheet_handle.clone(),
+                    sprite_number: i as usize,
+                });
+            };
+            ii += 1;
         };
     }
-    
+
     pub fn load_room(&mut self, world: &mut World, dimensions: &ScreenDimensions) {
         let mut x = 0.0;
         let mut y = 0.0;
 
-        for row in self.current.layers[0].tiles.iter().rev(){
+        const TILE_SIZE : f32 = 16.0;
+
+        for row in self.current.layers[0].tiles.iter().rev() {
             x = 0.0;
-            y += 16.0;
-            for col in row.iter(){
-                x += 16.0; 
+            y += TILE_SIZE;
+
+            for col in row.iter() {
+                x += TILE_SIZE; 
+
                 let mut transform = Transform::default();
                 transform.set_translation_xyz(x, y, 0.);
                 

--- a/src/state.rs
+++ b/src/state.rs
@@ -85,16 +85,16 @@ fn init_camera(world: &mut World, dimensions: &ScreenDimensions) {
 
 
 fn initialise_player(world: &mut World, sprite: &Vec<SpriteRender>) {
+    let mut player1 = Player::new( 64.0, 64.0 ); 
+
     let mut transform = Transform::default();
-    let mut p1 = Player::new( 64.0, 64.0 ); 
-    // Correctly position the paddles.
-    transform.set_translation_xyz(p1.x, p1.y, 0.0); 
+    transform.set_translation_xyz(player1.x, player1.y, 0.0); 
 
     // Create a player entity.
     world
         .create_entity()
         .with(sprite[125].clone())
-        .with(p1)
+        .with(player1)
         .with(transform)
         .build();
     

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,6 +5,7 @@ use amethyst::{
     window::ScreenDimensions,
     ecs::{Component, DenseVecStorage, FlaggedStorage},
 };
+use std::time::Instant;
 use log::info;
 
 use crate::map;
@@ -13,9 +14,10 @@ pub struct GamePlayState {
     pub current_map: map::Room,
 }
 
-pub struct Player{
+pub struct Player {
     pub x: f32,
     pub y: f32,
+    pub last_movement_instant: Instant,
 }
 
 impl Player {
@@ -23,11 +25,12 @@ impl Player {
         Player {
             x,
             y, 
+            last_movement_instant: Instant::now(),
         }
     }
 }
 
-impl Component for Player{
+impl Component for Player {
     type Storage = FlaggedStorage<Self, DenseVecStorage<Self>>;
 }
 

--- a/src/systems/player.rs
+++ b/src/systems/player.rs
@@ -3,11 +3,14 @@ use amethyst::derive::SystemDesc;
 use amethyst::ecs::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage};
 use amethyst::input::InputHandler;
 
+use std::time::Instant;
+
 use crate::state::{Player};
 use crate::key_bindings::{MovementBindingTypes, AxisBinding, ActionBinding};
 use log::info;
 
 const TILE_SIZE : f32 = 16.0;
+const MOVEMENT_DELAY_MS : u128 = 150;
 
 #[derive(SystemDesc)]
 pub struct PlayerSystem;
@@ -15,21 +18,27 @@ pub struct PlayerSystem;
 impl<'s> System<'s> for PlayerSystem{
     type SystemData = (
         WriteStorage<'s, Transform>,
-        ReadStorage<'s, Player>,
+        WriteStorage<'s, Player>,
         Read<'s, InputHandler<MovementBindingTypes>>,
     );
 
-    fn run(&mut self, (mut transforms, players, input): Self::SystemData) {
-        for (player, transform) in (&players, &mut transforms).join() {  
-            let horizontal = input
-                .axis_value(&AxisBinding::Horizontal)
-                .unwrap_or(0.0);
-            let vertical = input
-                .axis_value(&AxisBinding::Vertical)
-                .unwrap_or(0.0);
+    fn run(&mut self, (mut transforms, mut players, input): Self::SystemData) {
+        for (player, transform) in (&mut players, &mut transforms).join() {  
+            let now = Instant::now();
 
-            transform.move_up(vertical * TILE_SIZE);
-            transform.move_right(horizontal * TILE_SIZE);
+            if now.duration_since(player.last_movement_instant).as_millis() >= MOVEMENT_DELAY_MS {
+                let horizontal = input
+                    .axis_value(&AxisBinding::Horizontal)
+                    .unwrap_or(0.0);
+                let vertical = input
+                    .axis_value(&AxisBinding::Vertical)
+                    .unwrap_or(0.0);
+                
+                player.last_movement_instant = now.clone();
+
+                transform.move_up(vertical * TILE_SIZE);
+                transform.move_right(horizontal * TILE_SIZE);
+            }
         } 
     }
 }

--- a/src/systems/player.rs
+++ b/src/systems/player.rs
@@ -1,9 +1,13 @@
 use amethyst::core::{Transform, SystemDesc};
 use amethyst::derive::SystemDesc;
 use amethyst::ecs::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage};
-use amethyst::input::{InputHandler, StringBindings};
+use amethyst::input::InputHandler;
+
 use crate::state::{Player};
+use crate::key_bindings::{MovementBindingTypes, AxisBinding, ActionBinding};
 use log::info;
+
+const TILE_SIZE : f32 = 16.0;
 
 #[derive(SystemDesc)]
 pub struct PlayerSystem;
@@ -12,18 +16,20 @@ impl<'s> System<'s> for PlayerSystem{
     type SystemData = (
         WriteStorage<'s, Transform>,
         ReadStorage<'s, Player>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<MovementBindingTypes>>,
     );
 
     fn run(&mut self, (mut transforms, players, input): Self::SystemData) {
-        for (player, transform) in (&players, &mut transforms).join(){  
-            let xMove = input.action_is_down("up").unwrap_or(false);
+        for (player, transform) in (&players, &mut transforms).join() {  
+            let horizontal = input
+                .axis_value(&AxisBinding::Horizontal)
+                .unwrap_or(0.0);
+            let vertical = input
+                .axis_value(&AxisBinding::Vertical)
+                .unwrap_or(0.0);
 
-            if xMove {
-                info!("UP");  
-                // let xMove = 1.2 * mv_amount as f32;
-                transform.move_up(16.0);     
-            }
+            transform.move_up(vertical * TILE_SIZE);
+            transform.move_right(horizontal * TILE_SIZE);
         } 
     }
 }


### PR DESCRIPTION
This PRs would add two things:
- allow us to designate key bindings with enum variants instead of strings.
- movement rate limitation so that we can actually control our movements with the character.

Movement is limited to once every 150 ms, and is on a tile basis (can easily be modified).

I also made a few whitespace changes and renamed a couple variables to improve readability.

I suggest reviewing this b going through each commit individually.