### PR TITLE
Fix Github Actions CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,7 @@ authors = ["Team Awesome"]
 edition = "2018"
 
 [dependencies]
-# amethyst = { git = "https://github.com/machine-hum/amethyst" }
-# amethyst = { git = "https://github.com/amethyst/amethyst" }
-amethyst = { path = "../amethyst" }
-
-# amethyst = "0.15.0"
+amethyst = "0.15.0"
 log = { version = "0.4.8", features = ["serde"] }
 tiled = { git = "https://github.com/mattyhall/rs-tiled" }
 serde = { version = "1", features = ["derive"] }
@@ -23,13 +19,13 @@ array-init = "0.1.1"
 
 [features]
 default = ["vulkan"]   # Windows / Linux (make sure you have alsa-utils on linux installed)
-#default = ["metal"]     # macOS
+# default = ["metal"]     # macOS
 
 vulkan = ["amethyst/vulkan"]
 # nightly = ["amethyst/nightly"]
 metal = ["amethyst/metal"]
 
-#profile is set to the --release profile
+# profile is set to the --release profile
 [profile.dev]
 opt-level = 3
 debug = false


### PR DESCRIPTION
- Specify provider for Amethyst crate so that it can be found by Github Actions

Hi! This makes the CI check succeed on my fork, so it should fix it here as well. Apologies if I'm misunderstanding the way this is currently being done, but I figured CI should succeed when possible. If the purpose of `../amethyst` was to allow a separate local install of Amethyst (i.e. to avoid long recompiles), then there should still be a fix for CI. For example, an alternate build configuration could be specified for CI, or maybe a caching system could be used for Github Actions.

Very cool project, by the way! I discovered it through the Youtube video, and it looks like exactly the kind of ambitious project that the community needs.